### PR TITLE
Pretty printer: Guess field names

### DIFF
--- a/candid.cabal
+++ b/candid.cabal
@@ -94,6 +94,7 @@ test-suite test
         tasty >=0.7 && <1.5,
         tasty-hunit >=0.10.0.2 && <0.11,
         tasty-smallcheck >=0.8.1 && <0.9,
+        tasty-quickcheck >=0.8.1 && <0.9,
         tasty-rerun >=1.1.17 && <1.2,
         smallcheck >=1.1.7 && <1.2,
         candid -any,

--- a/src/Codec/Candid.hs
+++ b/src/Codec/Candid.hs
@@ -367,9 +367,15 @@ This library allows the parsing and pretty-printing of candid values. The binary
 >>> let bytes = encode (#bar .== Just 100 .+ #foo .== [True,False])
 >>> let Right vs = decodeVals bytes
 >>> pretty vs
-(record {4895187 = opt +100; 5097222 = vec {true; false}})
+(record {bar = opt +100; foo = vec {true; false}})
 
-As you can see, the binary format does not preserve the field names. Future versions of this library will allow you to specify the (dynamic) 'Type' at which you want to decode these values, to overcome that problem.
+If you know Candid well you might be surprised to see the fieldnames here, becuase the Candid binary format does actually transmit the field name, but only a hash. This library tries to invert this hash, trying to find the shortest field name consisting of lower case letters and underscores that is equivalent to it. It does not work always:
+
+>>> let Right vs = decodeVals $ encode (#stopped .== True .+ #canister_id .== Principal (BS.pack []))
+>>> pretty vs
+(record {stopped = true; hymijyo = service "aaaaa-aa"})
+
+Future versions of this library will allow you to specify the (dynamic) 'Type' at which you want to decode these values, in which case the field name would be taken from there.
 
 Conversely, you can encode from the textual representation:
 
@@ -379,8 +385,7 @@ Conversely, you can encode from the textual representation:
 >>> decode @(Rec ("bar" .== Maybe Integer .+ "foo" .== [Bool])) bytes
 Right (#bar .== Just 100 .+ #foo .== [True,False])
 
-
-This function does not support the full textual format yet; in particular type annotation can only be used around number literals.
+This function does not support the full textual format yet; in particular type annotations can only be used around number literals.
 
 -}
 

--- a/src/Codec/Candid/FieldName.hs
+++ b/src/Codec/Candid/FieldName.hs
@@ -8,6 +8,7 @@ module Codec.Candid.FieldName
   , hashedField
   , fieldHash
   , candidHash
+  , invertHash
   , unescapeFieldName
   , escapeFieldName
   ) where
@@ -17,7 +18,9 @@ import qualified Data.Text.Encoding as T
 import qualified Data.ByteString.Lazy as BS
 import Data.Text.Prettyprint.Doc
 import Data.String
+import Data.Maybe
 import Data.Word
+import Data.Char
 import Numeric.Natural
 import Data.Function
 import Text.Read (readMaybe)
@@ -39,7 +42,36 @@ hashedField h = FieldName h Nothing
 
 -- | The Candid field label hashing algorithm
 candidHash :: T.Text -> Word32
-candidHash s = BS.foldl (\h c -> (h * 223 + fromIntegral c)) 0 $ BS.fromStrict $ T.encodeUtf8 s
+candidHash s = BS.foldl (\h c -> h * 223 + fromIntegral c) 0 $ BS.fromStrict $ T.encodeUtf8 s
+
+-- | Inversion of the Candid field label hash
+invertHash :: Word32 -> Maybe T.Text
+invertHash w32 | w32 < 32 = Nothing
+    -- leave small numbers alone, tend to be tuple indicies
+invertHash w32 = listToMaybe guesses
+  where
+    x = fromIntegral w32 :: Word64
+    chars = ['a'..'z'] ++ ['_']
+    ords = 0 : map (fromIntegral . ord) chars
+    non_mod x = x - (x `mod` 2^(32::Int))
+    guesses =
+        [ T.pack $ reverse guess
+        | c8 <- ords, c7 <- ords, c6 <- ords, c5 <- ords
+        -- It seems that 8 characters are enough to invert anything
+        -- (based on quickchecking)
+        -- Set up so that short guesses come first
+        , let high_chars = c5 * 223^(4::Int) + c6 * 223^(5::Int) + c7 * 223^(6::Int) + c8 * 223^(7::Int)
+        , let guess = simple $ x + non_mod high_chars
+        , all (`elem` chars) guess
+        ]
+
+    -- inverts the Hash if the hash was created without modulos
+    -- returns string in reverse order
+    simple :: Word64 -> String
+    simple 0 = ""
+    simple x = chr (fromIntegral b) : simple a
+      where (a, b) = x `divMod` 223
+
 
 instance Eq FieldName where
     (==) = (==) `on` fieldHash
@@ -57,7 +89,9 @@ instance IsString FieldName where
 
 instance Pretty FieldName where
     pretty (FieldName _ (Just x)) = pretty x
-    pretty (FieldName h Nothing) = pretty h
+    pretty (FieldName h Nothing)
+        | Just x <- invertHash h  = pretty x
+        | otherwise               = pretty h
 
 
 -- | The inverse of 'escapeFieldName'

--- a/src/Codec/Candid/TestExports.hs
+++ b/src/Codec/Candid/TestExports.hs
@@ -3,6 +3,7 @@
 module Codec.Candid.TestExports
     ( module Codec.Candid.Parse
     , module Codec.Candid.TH
+    , module Codec.Candid.FieldName
     ) where
 
 import Codec.Candid.Parse
@@ -21,3 +22,6 @@ import Codec.Candid.TH
   )
 
 
+import Codec.Candid.FieldName
+  ( invertHash
+  )

--- a/test/test.hs
+++ b/test/test.hs
@@ -33,7 +33,6 @@ import qualified Test.Tasty.QuickCheck as QC
 import Test.SmallCheck.Series
 import Data.Void
 import Data.Either
-import Data.Maybe
 import GHC.Int
 import GHC.Word
 import Numeric.Natural
@@ -320,9 +319,9 @@ tests = testGroup "tests"
           show (pretty vs) @?= e
     in
     [ t True "(true)"
-    , t (SimpleRecord False 42) "(record {4895187 = (42 : nat8); 5097222 = false})"
-    , t (JustRight (Just (3 :: Natural))) "(variant {2089909180 = opt 3})"
-    , t (JustRight (3 :: Word8)) "(variant {2089909180 = (3 : nat8)})"
+    , t (SimpleRecord False 42) "(record {bar = (42 : nat8); foo = false})"
+    , t (JustRight (Just (3 :: Natural))) "(variant {gp_jocd = opt 3})"
+    , t (JustRight (3 :: Word8)) "(variant {gp_jocd = (3 : nat8)})"
     , t () "()"
     , t (Unary ()) "(null)"
     , t (Unary (True, False)) "(record {true; false})"


### PR DESCRIPTION
Candid binary data does not have field names, but only hashes of field
names. When decoding these values without knowing the expected field
names, the user only sees these numbers, which is not very helpful.

For short field names (≤ 4 characters), the string can be recovered from
the name. So let’s do that.

For larger field names, we can guess. Turns out that it is pretty fast
(2.2ms on my laptop) to find _some_ field name consisting of only lower
characters and underscores. This actually picks the right word for (e.g.
`stopped` is correctly inverted).

For others, you get some garbled string.  This is maybe still better
than a number (for example, one might begin to recognize `"hymijyo"` as
equivalent to `"canister_id"`, which is arguably easier to remember
than `1313628723`.