### PR TITLE
Ignore init arguments

### DIFF
--- a/src/Codec/Candid/Parse.hs
+++ b/src/Codec/Candid/Parse.hs
@@ -74,8 +74,11 @@ importP :: Parser [DidDef TypeName]
 importP = withPredicate (const (Left "imports not yet supported")) $
     [] <$ k "import"
 
+-- NOTE: This discards "init" arguments:
+-- https://github.com/dfinity/candid/blob/master/spec/Candid.md#core-grammar
+-- See also https://github.com/nomeata/haskell-candid/issues/16
 actorP :: Parser (DidService TypeName)
-actorP = k "service" *> optional idP *> s ":" *> actorTypeP -- TODO could be a type id
+actorP = k "service" *> optional idP *> s ":" *> optional (seqP *> s"->") *> actorTypeP -- TODO could be a type id
 
 actorTypeP :: Parser (DidService TypeName)
 actorTypeP = braceSemi methP

--- a/test/test.hs
+++ b/test/test.hs
@@ -398,6 +398,8 @@ tests = testGroup "tests"
       DidFile [] [("foo", MethodType [TextT] [TextT] True True)]
     , parseTest "service : { foo : (text) -> (text) oneway query }" $
       DidFile [] [("foo", MethodType [TextT] [TextT] True True)]
+    , parseTest "service : (opt SomeInit) -> { foo : (text) -> (text) oneway query }" $
+      DidFile [] [("foo", MethodType [TextT] [TextT] True True)]
     , parseTest "type t = int; service : { foo : (t) -> (t) }" $
       DidFile [("t", IntT)] [("foo", MethodType [RefT "t"] [RefT "t"] False False)]
     ]


### PR DESCRIPTION
_I'm leaving #16 open until I (or someone else) actually finds the time to update `DidService`._

This drops "init" arguments, as in the following:

``` candid
service foo: (opt SomeArgs) -> {
...
};
```

Actually recording them in the resulting `DidService` would be great but
would require changing a fair bit of code. For now this helps in
situations where haskell-candid just chokes on `.did` files that have
such args.